### PR TITLE
Unset with nil, fix performance by removing default limit=0, convenience methods removed? persisted? and _id!

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -12,6 +12,6 @@ description: |
 dependencies:
   cryomongo:
     github: elbywan/cryomongo
-    version: ~> 0.2.0
+    version: ~> 0.2.3
 
 license: MIT

--- a/spec/models_spec.cr
+++ b/spec/models_spec.cr
@@ -23,6 +23,7 @@ describe Moongoon::Collection do
 
   before_each {
     Model.clear
+    Moongoon::Config.reset
   }
 
   describe "Get" do
@@ -149,7 +150,18 @@ describe Moongoon::Collection do
       Model.find_by_id!(model.id!).age.should eq 15
     end
 
-    it "#update (with unsets)" do
+    it "#update skip nils" do
+      models = Model.insert_models raw_models
+      model = models[2]
+      model.humor = nil
+      model = model.update
+      Model.find_by_id!(model.id!).humor.should eq 15
+    end
+
+    it "#update unset nils" do
+      Moongoon.config do |config|
+        config.unset_nils = true
+      end
       models = Model.insert_models raw_models
       model = models[2]
       model.humor = nil
@@ -172,7 +184,18 @@ describe Moongoon::Collection do
       Model.find_by_id!(model.id!).age.should eq 15
     end
 
-    it "#update_query (with unsets)" do
+    it "#update_query (skip nils)" do
+      models = Model.insert_models raw_models
+      model = models[1]
+      model.humor = nil
+      model.update_query({_id: model._id})
+      Model.find_by_id!(model.id!).humor.should eq 0
+    end
+
+    it "#update_query (unset nils)" do
+      Moongoon.config do |config|
+        config.unset_nils = true
+      end
       models = Model.insert_models raw_models
       model = models[1]
       model.humor = nil

--- a/spec/models_spec.cr
+++ b/spec/models_spec.cr
@@ -5,6 +5,7 @@ private class Model < Moongoon::Collection
 
   property name : String
   property age : Int32
+  property humor : Int32?
 
   def self.insert_models(models)
     models.map { |model|
@@ -15,9 +16,9 @@ end
 
 describe Moongoon::Collection do
   raw_models = [
-    {name: "one", age: 10},
-    {name: "two", age: 10},
-    {name: "three", age: 20},
+    {name: "one", age: 10, humor: nil},
+    {name: "two", age: 10, humor: 0},
+    {name: "three", age: 20, humor: 15},
   ]
 
   before_each {
@@ -148,6 +149,14 @@ describe Moongoon::Collection do
       Model.find_by_id!(model.id!).age.should eq 15
     end
 
+    it "#update (with unsets)" do
+      models = Model.insert_models raw_models
+      model = models[2]
+      model.humor = nil
+      model = model.update
+      Model.find_by_id!(model.id!).humor.should eq nil
+    end
+
     it "#self.update" do
       models = Model.insert_models raw_models
       model = models[1]
@@ -161,6 +170,14 @@ describe Moongoon::Collection do
       model.age = 15
       model.update_query({_id: model._id})
       Model.find_by_id!(model.id!).age.should eq 15
+    end
+
+    it "#update_query (with unsets)" do
+      models = Model.insert_models raw_models
+      model = models[1]
+      model.humor = nil
+      model.update_query({_id: model._id})
+      Model.find_by_id!(model.id!).humor.should eq nil
     end
 
     it "#self.update_by_id" do

--- a/spec/models_spec.cr
+++ b/spec/models_spec.cr
@@ -159,7 +159,7 @@ describe Moongoon::Collection do
     end
 
     it "#update unset nils" do
-      Moongoon.config do |config|
+      Moongoon.configure do |config|
         config.unset_nils = true
       end
       models = Model.insert_models raw_models
@@ -193,7 +193,7 @@ describe Moongoon::Collection do
     end
 
     it "#update_query (unset nils)" do
-      Moongoon.config do |config|
+      Moongoon.configure do |config|
         config.unset_nils = true
       end
       models = Model.insert_models raw_models

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -46,7 +46,13 @@ end
   ::Moongoon.database.command(Mongo::Commands::DropDatabase)
 }
 
-::Moongoon.connect(
-  ENV.fetch("MONGO_URL", "mongodb://localhost:27017"),
-  database_name: "moongoon_test"
-)
+if override_url = ENV["MONGO_URL"]?
+  ::Moongoon.connect(
+    override_url,
+    database_name: "moongoon_test"
+  )
+else
+  ::Moongoon.connect(
+    database_name: "moongoon_test"
+  )
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -45,6 +45,8 @@ end
 ::Moongoon.after_connect_before_scripts {
   ::Moongoon.database.command(Mongo::Commands::DropDatabase)
 }
+
 ::Moongoon.connect(
+  ENV.fetch("MONGO_URL", "mongodb://localhost:27017"),
   database_name: "moongoon_test"
 )

--- a/src/config.cr
+++ b/src/config.cr
@@ -1,0 +1,28 @@
+module Moongoon
+  class Config
+    @@instance : self = self.new
+
+    def self.reset
+      @@instance = self.new
+    end
+
+    def self.singleton
+      @@instance
+    end
+
+    @unset_nils : Bool
+    property unset_nils
+
+    def initialize
+      @unset_nils = false
+    end
+  end
+
+  def self.config
+    yield Config.singleton
+  end
+
+  def self.config
+    Config.singleton
+  end
+end

--- a/src/config.cr
+++ b/src/config.cr
@@ -18,7 +18,7 @@ module Moongoon
     end
   end
 
-  def self.config
+  def self.configure
     yield Config.singleton
   end
 

--- a/src/models/database/internal.cr
+++ b/src/models/database/internal.cr
@@ -4,7 +4,7 @@ module Moongoon::Traits::Database::Internal
 
   # Query builders #
 
-  protected def self.format_aggregation(query, stages, fields = nil, order_by = nil, skip = 0, limit : Int32? = 0)
+  protected def self.format_aggregation(query, stages, fields = nil, order_by = nil, skip = 0, limit : Int? = 0)
     pipeline = query && !query.empty? ? [
       BSON.new({"$match": BSON.new(query)}),
     ] : [] of BSON
@@ -21,8 +21,8 @@ module Moongoon::Traits::Database::Internal
     if skip > 0
       pipeline << BSON.new({"$skip": skip.to_i32})
     end
-    if (limit_i32 = limit) && limit_i32 > 0
-      pipeline << BSON.new({"$limit": limit_i32})
+    if (l = limit) && l > 0
+      pipeline << BSON.new({"$limit": l.to_i32})
     end
     pipeline
   end

--- a/src/models/database/internal.cr
+++ b/src/models/database/internal.cr
@@ -2,19 +2,6 @@
 module Moongoon::Traits::Database::Internal
   extend self
 
-  # Utilities #
-
-  def bson_id(id : String | BSON::ObjectId | Nil)
-    case id
-    when String
-      BSON::ObjectId.new id
-    when BSON::ObjectId
-      id
-    when Nil
-      nil
-    end
-  end
-
   # Query builders #
 
   protected def self.format_aggregation(query, stages, fields = nil, order_by = nil, skip = 0, limit : Int32? = 0)
@@ -60,5 +47,16 @@ module Moongoon::Traits::Database::Internal
   # Raises if the Model has a nil id field.
   private def id_check!
     raise ::Moongoon::Error::NotFound.new unless self._id
+  end
+
+  protected def self.bson_id(id : String | BSON::ObjectId | Nil)
+    case id
+    when String
+      BSON::ObjectId.new id
+    when BSON::ObjectId
+      id
+    when Nil
+      nil
+    end
   end
 end

--- a/src/models/database/internal.cr
+++ b/src/models/database/internal.cr
@@ -16,7 +16,6 @@ module Moongoon::Traits::Database::Internal
       pipeline << BSON.new({"$project": BSON.new(fields)})
     end
     if order_by
-      {{ debug() }}
       pipeline << BSON.new({"$sort": BSON.new(order_by)})
     end
     if skip > 0

--- a/src/models/database/internal.cr
+++ b/src/models/database/internal.cr
@@ -4,14 +4,12 @@ module Moongoon::Traits::Database::Internal
 
   # Utilities #
 
-  def bson_id(id : String | BSON::ObjectId | Nil)
+  def bson_id(id : String | BSON::ObjectId)
     case id
     when String
       BSON::ObjectId.new id
     when BSON::ObjectId
       id
-    when Nil
-      BSON::ObjectId.new ""
     end
   end
 
@@ -41,11 +39,11 @@ module Moongoon::Traits::Database::Internal
     pipeline
   end
 
-  protected def self.concat_id_filter(query, id : BSON::ObjectId | String | Nil)
+  protected def self.concat_id_filter(query, id : BSON::ObjectId | String)
     BSON.new({"_id": self.bson_id(id)}).append(BSON.new(query))
   end
 
-  protected def self.concat_ids_filter(query, ids : Array(BSON::ObjectId?) | Array(String?))
+  protected def self.concat_ids_filter(query, ids : Array(BSON::ObjectId) | Array(String))
     BSON.new({
       "_id" => {
         "$in" => ids.map { |id|

--- a/src/models/database/internal.cr
+++ b/src/models/database/internal.cr
@@ -4,7 +4,7 @@ module Moongoon::Traits::Database::Internal
 
   # Query builders #
 
-  protected def self.format_aggregation(query, stages, fields = nil, order_by = nil, skip = 0, limit : Int? = 0)
+  protected def self.format_aggregation(query, stages, fields = nil, order_by = nil, skip = 0, limit : Int? = nil)
     pipeline = query && !query.empty? ? [
       BSON.new({"$match": BSON.new(query)}),
     ] : [] of BSON

--- a/src/models/database/internal.cr
+++ b/src/models/database/internal.cr
@@ -52,7 +52,7 @@ module Moongoon::Traits::Database::Internal
   protected def self.bson_id(id : String | BSON::ObjectId | Nil)
     case id
     when String
-      BSON::ObjectId.new id
+      id.blank? ? nil : BSON::ObjectId.new(id)
     when BSON::ObjectId
       id
     when Nil

--- a/src/models/database/methods/delete.cr
+++ b/src/models/database/methods/delete.cr
@@ -53,7 +53,7 @@ module Moongoon::Traits::Database::Methods::Delete
     # User.remove id, query: { name: "John" }
     # ```
     def self.remove_by_id(id, query = BSON.new, **args) : Mongo::Commands::Common::DeleteResult?
-      full_query = ::Moongoon::Traits::Database::Internal.concat_id_filter(query, id)
+      full_query = ::Moongoon::Traits::Database::Internal.concat_id_filter(query, id!)
       remove(full_query)
     end
 

--- a/src/models/database/methods/delete.cr
+++ b/src/models/database/methods/delete.cr
@@ -22,6 +22,7 @@ module Moongoon::Traits::Database::Methods::Delete
       full_query = ::Moongoon::Traits::Database::Internal.concat_id_filter(query, id!)
       self.class.before_remove_call(self) unless no_hooks
       result = self.class.collection.delete_one(full_query, **args)
+      @removed = true
       self.class.after_remove_call(self) unless no_hooks
       result
     end

--- a/src/models/database/methods/delete.cr
+++ b/src/models/database/methods/delete.cr
@@ -53,7 +53,7 @@ module Moongoon::Traits::Database::Methods::Delete
     # User.remove id, query: { name: "John" }
     # ```
     def self.remove_by_id(id, query = BSON.new, **args) : Mongo::Commands::Common::DeleteResult?
-      full_query = ::Moongoon::Traits::Database::Internal.concat_id_filter(query, id!)
+      full_query = ::Moongoon::Traits::Database::Internal.concat_id_filter(query, id)
       remove(full_query)
     end
 

--- a/src/models/database/methods/get.cr
+++ b/src/models/database/methods/get.cr
@@ -66,7 +66,7 @@ module Moongoon::Traits::Database::Methods::Get
     #
     # NOTE: Other arguments are available but will not be documented here.
     # For more details check out the underlying [`cryomongo`](https://github.com/elbywan/cryomongo) driver documentation and code.
-    def self.find(query = BSON.new, order_by = { _id: -1 }, fields = @@default_fields, skip = 0, limit = 0, **args) : Array(self)
+    def self.find(query = BSON.new, order_by : NamedTuple = { _id: -1 }, fields = @@default_fields, skip = 0, limit = 0, **args) : Array(self)
       items = [] of self
 
       if stages = @@aggregation_stages
@@ -150,7 +150,7 @@ module Moongoon::Traits::Database::Methods::Get
     # ```
     # user = User.find_by_id(123456)
     # ```
-    def self.find_by_id(id : String, query = BSON.new, order_by = { _id: -1 }, fields = @@default_fields, **args) : self?
+    def self.find_by_id(id : BSON::ObjectId | String, query = BSON.new, order_by = { _id: -1 }, fields = @@default_fields, **args) : self?
       item = uninitialized BSON?
       query = ::Moongoon::Traits::Database::Internal.concat_id_filter(query, id)
       item = if stages = @@aggregation_stages

--- a/src/models/database/methods/get.cr
+++ b/src/models/database/methods/get.cr
@@ -66,7 +66,7 @@ module Moongoon::Traits::Database::Methods::Get
     #
     # NOTE: Other arguments are available but will not be documented here.
     # For more details check out the underlying [`cryomongo`](https://github.com/elbywan/cryomongo) driver documentation and code.
-    def self.find(query = BSON.new, order_by : NamedTuple = { _id: -1 }, fields = @@default_fields, skip = 0, limit : Int32? = nil, **args) : Array(self)
+    def self.find(query = BSON.new, order_by = { _id: -1 }, fields = @@default_fields, skip = 0, limit : Int? = nil, **args) : Array(self)
       items = [] of self
 
       if stages = @@aggregation_stages

--- a/src/models/database/methods/get.cr
+++ b/src/models/database/methods/get.cr
@@ -66,7 +66,7 @@ module Moongoon::Traits::Database::Methods::Get
     #
     # NOTE: Other arguments are available but will not be documented here.
     # For more details check out the underlying [`cryomongo`](https://github.com/elbywan/cryomongo) driver documentation and code.
-    def self.find(query = BSON.new, order_by : NamedTuple = { _id: -1 }, fields = @@default_fields, skip = 0, limit = 0, **args) : Array(self)
+    def self.find(query = BSON.new, order_by : NamedTuple = { _id: -1 }, fields = @@default_fields, skip = 0, limit : Int32? = nil, **args) : Array(self)
       items = [] of self
 
       if stages = @@aggregation_stages

--- a/src/models/database/methods/patch.cr
+++ b/src/models/database/methods/patch.cr
@@ -66,13 +66,16 @@ module Moongoon::Traits::Database::Methods::Patch
     # ```
     def update_query(query, no_hooks = false, **args) : self
       self.class.before_update_call(self) unless no_hooks
+      changes = BSON.new({
+        "$set": self.to_bson
+      })
+      if unsets = self.unsets_to_bson
+        changes["$unset"] = unsets
+      end
       self.class.collection.update_many(
         query,
         **args,
-        update: {
-          "$set": self.to_bson,
-          "$unset": self.unsets_to_bson
-        }
+        update: changes
       )
       self.class.after_update_call(self) unless no_hooks
       self

--- a/src/models/database/methods/patch.cr
+++ b/src/models/database/methods/patch.cr
@@ -69,7 +69,7 @@ module Moongoon::Traits::Database::Methods::Patch
       changes = BSON.new({
         "$set": self.to_bson
       })
-      if unsets = self.unsets_to_bson
+      if ::Moongoon.config.unset_nils && (unsets = self.unsets_to_bson)
         changes["$unset"] = unsets
       end
       self.class.collection.update_many(

--- a/src/models/database/methods/patch.cr
+++ b/src/models/database/methods/patch.cr
@@ -27,7 +27,7 @@ module Moongoon::Traits::Database::Methods::Patch
     # ```
     def update(query = BSON.new, **args) : self
       id_check!
-      query = ::Moongoon::Traits::Database::Internal.concat_id_filter(query, id)
+      query = ::Moongoon::Traits::Database::Internal.concat_id_filter(query, _id!)
       self.update_query(query, **args)
     end
 
@@ -90,7 +90,7 @@ module Moongoon::Traits::Database::Methods::Patch
     # # Updates the user only if he/she is named John.
     # User.update_by_id(id, query: { name: "John" }, update: { "$set": { name: "Igor" }})
     # ```
-    def self.update_by_id(id, update, query = BSON.new, **args) : Mongo::Commands::Common::UpdateResult?
+    def self.update_by_id(id : BSON::ObjectId | String, update, query = BSON.new, **args) : Mongo::Commands::Common::UpdateResult?
       query = ::Moongoon::Traits::Database::Internal.concat_id_filter(query, id)
       update(query, update, **args)
     end
@@ -137,7 +137,7 @@ module Moongoon::Traits::Database::Methods::Patch
     # Modifies and returns a single document.
     #
     # Similar to `self.find_and_modify`, except that a matching on the `_id` field will be added to the *query* argument.
-    def self.find_and_modify_by_id(id, update, query = BSON.new, no_hooks = false, **args)
+    def self.find_and_modify_by_id(id : BSON::ObjectId | String, update, query = BSON.new, no_hooks = false, **args)
       query = ::Moongoon::Traits::Database::Internal.concat_id_filter(query, id)
       find_and_modify(query, update, **args)
     end

--- a/src/models/database/methods/patch.cr
+++ b/src/models/database/methods/patch.cr
@@ -69,7 +69,10 @@ module Moongoon::Traits::Database::Methods::Patch
       self.class.collection.update_many(
         query,
         **args,
-        update: {"$set": self.to_bson}
+        update: {
+          "$set": self.to_bson,
+          "$unset": self.unsets_to_bson
+        }
       )
       self.class.after_update_call(self) unless no_hooks
       self

--- a/src/models/models.cr
+++ b/src/models/models.cr
@@ -68,7 +68,8 @@ module Moongoon
     end
 
     # Copying and hacking BSON::Serializable for now - but ideally we'd just add more flexibility there? (options[force_emit_nil: true] or something?)
-    def unsets_to_bson(bson = BSON.new)
+    def unsets_to_bson : BSON?
+      bson = BSON.new
       {% begin %}
       {% global_options = @type.annotations(BSON::Options) %}
       {% camelize = global_options.reduce(false) { |_, a| a[:camelize] } %}
@@ -86,7 +87,7 @@ module Moongoon
         {% end %}
       {% end %}
       {% end %}
-      bson
+      bson.empty? ? nil : bson
     end
 
     # Instantiate a named tuple from the model instance properties.

--- a/src/models/models.cr
+++ b/src/models/models.cr
@@ -18,10 +18,6 @@ module Moongoon
     include JSON::Serializable
     include BSON::Serializable
 
-    @[JSON::Field(ignore: true)]
-    @[BSON::Field(ignore: true)]
-    getter? removed = false
-
     # Creates a new instance of the class from variadic arguments.
     #
     # ```
@@ -49,45 +45,6 @@ module Moongoon
         {% end %}
       {% end %}
       instance
-    end
-
-    def _id!
-      self._id.not_nil!
-    end
-
-    def id!
-      self.id.not_nil!
-    end
-
-    def persisted?
-      self.inserted? && !self.removed?
-    end
-
-    def inserted?
-      self._id != nil
-    end
-
-    # Copying and hacking BSON::Serializable for now - but ideally we'd just add more flexibility there? (options[force_emit_nil: true] or something?)
-    def unsets_to_bson : BSON?
-      bson = BSON.new
-      {% begin %}
-      {% global_options = @type.annotations(BSON::Options) %}
-      {% camelize = global_options.reduce(false) { |_, a| a[:camelize] } %}
-      {% for ivar in @type.instance_vars %}
-        {% ann = ivar.annotation(BSON::Field) %}
-        {% typ = ivar.type.union_types.select { |t| t != Nil }[0] %}
-        {% key = ivar.name %}
-        {% bson_key = ann ? ann[:key].id : camelize ? ivar.name.camelcase(lower: camelize == "lower") : ivar.name %}
-        {% unless ann && ann[:ignore] %}
-          {% unless ann && ann[:emit_null] %} #confusing, but it will be picked up by normal to_bson so we don't need it here
-            if self.{{ key }}.nil?
-              bson["{{ bson_key }}"] = nil
-            end
-          {% end %}
-        {% end %}
-      {% end %}
-      {% end %}
-      bson.empty? ? nil : bson
     end
 
     # Instantiate a named tuple from the model instance properties.
@@ -142,8 +99,30 @@ module Moongoon
         class_getter collection_name : String = \{{ value }}
       end
 
+      # Returns true if the document has been removed from the db
+      @[JSON::Field(ignore: true)]
+      @[BSON::Field(ignore: true)]
+      getter? removed = false
+
+      # Returns true if the document has been inserted and not yet removed
+      def persisted?
+        self.inserted? && !self.removed?
+      end
+
+      # Returns true if the document has been inserted (i.e. has an id)
+      def inserted?
+        self._id != nil
+      end
+
       # The MongoDB internal id representation.
       property _id : BSON::ObjectId?
+
+      # Returns the MongoDB bson _id
+      #
+      # Will raise if _id is nil.
+      def _id!
+        self._id.not_nil!
+      end
 
       # Set a MongoDB bson _id from a String.
       def id=(id : String)
@@ -182,6 +161,29 @@ module Moongoon
   # ```
   abstract class Collection < MongoBase
     include ::Moongoon::Traits::Database::Full
+
+    # Copying and hacking BSON::Serializable for now - but ideally we'd just add more flexibility there? (options[force_emit_nil: true] or something?)
+    def unsets_to_bson : BSON?
+      bson = BSON.new
+      {% begin %}
+      {% global_options = @type.annotations(BSON::Options) %}
+      {% camelize = global_options.reduce(false) { |_, a| a[:camelize] } %}
+      {% for ivar in @type.instance_vars %}
+        {% ann = ivar.annotation(BSON::Field) %}
+        {% typ = ivar.type.union_types.select { |t| t != Nil }[0] %}
+        {% key = ivar.name %}
+        {% bson_key = ann ? ann[:key].id : camelize ? ivar.name.camelcase(lower: camelize == "lower") : ivar.name %}
+        {% unless ann && ann[:ignore] %}
+          {% unless ann && ann[:emit_null] %} #confusing, but it will be picked up by normal to_bson so we don't need it here
+            if self.{{ key }}.nil?
+              bson["{{ bson_key }}"] = nil
+            end
+          {% end %}
+        {% end %}
+      {% end %}
+      {% end %}
+      bson.empty? ? nil : bson
+    end
 
     # Include this module to enable resource versioning.
     module Versioning

--- a/src/models/models.cr
+++ b/src/models/models.cr
@@ -60,10 +60,10 @@ module Moongoon
     end
 
     def persisted?
-      self.persisted_ever? && !self.removed?
+      self.inserted? && !self.removed?
     end
 
-    def persisted_ever?
+    def inserted?
       self._id != nil
     end
 

--- a/src/models/models.cr
+++ b/src/models/models.cr
@@ -59,25 +59,6 @@ module Moongoon
       self.id.not_nil!
     end
 
-    def self.find_in_batches(query = BSON.new, order_by : NamedTuple = {_id: -1}, batch_size = 100, skip = 0, limit = 0)
-      current_offset = skip
-      total_results = 0
-
-      until total_results >= limit
-        pull_limit = Math.min(limit - total_results, batch_size)
-
-        results = self.find(query: query, order_by: order_by, skip: current_offset, limit: pull_limit)
-        total_results += results.size
-        return if results.empty?
-
-        results.each do |doc|
-          yield doc
-        end
-
-        current_offset += batch_size
-      end
-    end
-
     def persisted?
       self.persisted_ever? && !self.removed?
     end

--- a/src/models/models.cr
+++ b/src/models/models.cr
@@ -27,20 +27,17 @@ module Moongoon
       instance = self.allocate
       {% begin %}
         {% for ivar in @type.instance_vars %}
-          {% ann = ivar.annotation(::BSON::Field) %}
-          {% unless (ann && ann[:ignore]) %}
-            {% default_value = ivar.default_value %}
-            {% if ivar.type.nilable? %}
-              instance.{{ivar.id}} = args["{{ivar.id}}"]? {% if ivar.has_default_value? %}|| {{ default_value }}{% end %}
-            {% else %}
-              if value = args["{{ivar.id}}"]?
-                instance.{{ivar.id}} = value
-              {% if ivar.has_default_value? %}
-              else
-                instance.{{ivar.id}} = {{ default_value }}
-              {% end %}
-              end
+          {% default_value = ivar.default_value %}
+          {% if ivar.type.nilable? %}
+            instance.{{ivar.id}} = args["{{ivar.id}}"]? {% if ivar.has_default_value? %}|| {{ default_value }}{% end %}
+          {% else %}
+            if value = args["{{ivar.id}}"]?
+              instance.{{ivar.id}} = value
+            {% if ivar.has_default_value? %}
+            else
+              instance.{{ivar.id}} = {{ default_value }}
             {% end %}
+            end
           {% end %}
         {% end %}
       {% end %}
@@ -61,10 +58,7 @@ module Moongoon
       {% begin %}
       {
       {% for ivar in @type.instance_vars %}
-        {% ann = ivar.annotation(::BSON::Field) %}
-        {% unless ann && ann[:ignore] %}
-          "{{ ivar.name }}": self.{{ ivar.name }},
-        {% end %}
+        "{{ ivar.name }}": self.{{ ivar.name }},
       {% end %}
       }
       {% end %}
@@ -102,7 +96,7 @@ module Moongoon
       # Returns true if the document has been removed from the db
       @[JSON::Field(ignore: true)]
       @[BSON::Field(ignore: true)]
-      getter? removed = false
+      property? removed = false
 
       # Returns true if the document has been inserted and not yet removed
       def persisted?

--- a/src/moongoon.cr
+++ b/src/moongoon.cr
@@ -1,6 +1,7 @@
 require "log"
 require "cryomongo"
 
+require "./config"
 require "./errors"
 require "./database"
 require "./models"


### PR DESCRIPTION
Sorry this is a bunch of fairly unrelated changes... there are a few things I'm not sure about, so please let me know any modifications you'd like made and I'll be happy happy to make them!

1. in my use-case, I often need to unset fields in mongo (e.g. user timezone is a string or nil to inherit from account timezone... if the user chooses Default I need to wipe the field from the record), so this adds support to do that by `user.timezone = nil` will issue an $unset command
2. because 0 != nil, a limit=0 was being passed to find operations, which apparently caused the batch_size to be set to 0 as well (no records returned initially and then one at time)... i discovered this cause it took several seconds to pull 240 records, and it turned out it was issuing ~240 Mongo::Commands::GetMore commands
3. BSON::ObjectId support in find_by_id (and prevent BSON::ObjectId.new("") because that led to weird data corruption in queries)
4. ability to override the spec db url with ENV["MONGO_URL"]
5. inserted? removed? persisted? and _id! methods on MongoBase
6. respect BSON::Field ignore:true annotations (just like the BSON library does)